### PR TITLE
Fix/227 monsterpi is not supported for raspberry pi 5

### DIFF
--- a/docs/installing/monsterpi.mdx
+++ b/docs/installing/monsterpi.mdx
@@ -15,7 +15,7 @@ Depending on the image, either [MongoDB](https://www.mongodb.com/) or [SQLite](h
 ## Hardware requirements
 
 :::warning
-A Raspberry Pi 5 has been tested and will not work. The MonsterPi team is aware of this issue.
+A Raspberry Pi 5 has been tested and will not work. The MonsterPi team is aware of this. Users interested in MonsterPi for the Raspberry Pi 5 can follow [this GitHub issue](https://github.com/fdm-monster/MonsterPi/issues/82) for any progress.
 :::
 
 :::warning
@@ -25,7 +25,7 @@ An Orange Pi or any other Single Board Computer (SBC) has not been tested and wi
 We advise you to get these components for your setup. You might already have these or equivalents of them. All links point to the official Raspberry Pi website. From there links to (local) stores are provided.
 
 | Component | Raspberry Pi 3 | Raspberry Pi 4 |
-|---|---|---|---|
+|---|---|---|
 | Raspberry Pi | [Link](https://www.raspberrypi.com/products/raspberry-pi-3-model-b/) | [Link](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) |
 | Raspberry Pi Case | [Link](https://www.raspberrypi.com/products/raspberry-pi-3-case/) | [Link](https://www.raspberrypi.com/products/raspberry-pi-4-case/) |
 | Cooling | Not Required | [Link](https://www.raspberrypi.com/products/raspberry-pi-4-case-fan/) |

--- a/docs/installing/monsterpi.mdx
+++ b/docs/installing/monsterpi.mdx
@@ -15,18 +15,22 @@ Depending on the image, either [MongoDB](https://www.mongodb.com/) or [SQLite](h
 ## Hardware requirements
 
 :::warning
+A Raspberry Pi 5 has been tested and will not work. The MonsterPi team is aware of this issue.
+:::
+
+:::warning
 An Orange Pi or any other Single Board Computer (SBC) has not been tested and will most likely not work.
 :::
 
 We advise you to get these components for your setup. You might already have these or equivalents of them. All links point to the official Raspberry Pi website. From there links to (local) stores are provided.
 
-| Component | Raspberry Pi 3 | Raspberry Pi 4 | Raspberry Pi 5 |
+| Component | Raspberry Pi 3 | Raspberry Pi 4 |
 |---|---|---|---|
-| Raspberry Pi | [Link](https://www.raspberrypi.com/products/raspberry-pi-3-model-b/) | [Link](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) | [Link](https://www.raspberrypi.com/products/raspberry-pi-5/) |
-| Raspberry Pi Case | [Link](https://www.raspberrypi.com/products/raspberry-pi-3-case/) | [Link](https://www.raspberrypi.com/products/raspberry-pi-4-case/) | [Link](https://www.raspberrypi.com/products/raspberry-pi-5-case/) |
-| Cooling | Not Required | [Link](https://www.raspberrypi.com/products/raspberry-pi-4-case-fan/) | Included with case |
-| Power Supply | [Link](https://www.raspberrypi.com/products/micro-usb-power-supply/) | [Link](https://www.raspberrypi.com/products/type-c-power-supply/) | [Link](https://www.raspberrypi.com/products/27w-power-supply/) |
-| 16GB or bigger Class 10 SD Card<br />Please get a decent brand<br />**do not save money on this**| [Link](https://www.raspberrypi.com/products/sd-cards/) |[Link](https://www.raspberrypi.com/products/sd-cards/)|[Link](https://www.raspberrypi.com/products/sd-cards/)|
+| Raspberry Pi | [Link](https://www.raspberrypi.com/products/raspberry-pi-3-model-b/) | [Link](https://www.raspberrypi.com/products/raspberry-pi-4-model-b/) |
+| Raspberry Pi Case | [Link](https://www.raspberrypi.com/products/raspberry-pi-3-case/) | [Link](https://www.raspberrypi.com/products/raspberry-pi-4-case/) |
+| Cooling | Not Required | [Link](https://www.raspberrypi.com/products/raspberry-pi-4-case-fan/) |
+| Power Supply | [Link](https://www.raspberrypi.com/products/micro-usb-power-supply/) | [Link](https://www.raspberrypi.com/products/type-c-power-supply/) |
+| 16GB or bigger Class 10 SD Card<br />Please get a decent brand<br />**do not save money on this**| [Link](https://www.raspberrypi.com/products/sd-cards/) |[Link](https://www.raspberrypi.com/products/sd-cards/)|
 
 Additionally, depending on your device, you might need a SD Card reader and (optionally) an micro SD Card to SD Card adapter.
 


### PR DESCRIPTION
Fixes docs to not show Raspberry Pi 5 as supported / tested.

![image](https://github.com/user-attachments/assets/8ee7c2b0-8e64-489e-85a0-1201d6bffbb8)
Refer to github issue for progress on Raspberry Pi 5 support for MonsterPi.