### PR TITLE
docs: print file routing

### DIFF
--- a/docs/configuration/environment_variables.mdx
+++ b/docs/configuration/environment_variables.mdx
@@ -69,7 +69,7 @@ FDM Monster can watch a folder and route dropped files to the right printer auto
 |--------------------------|-----------|------------------------------------------------------------------------------------------------------|
 | `WATCHED_FOLDER_PATH`    | -         | Absolute path to the folder FDM Monster watches. Unset disables the feature.                          |
 | `WATCHED_FOLDER_MODE`    | `consume` | `consume` moves imported files out of the folder; `library` copies them, leaving the originals.       |
-| `WATCHED_FOLDER_POLLING` | `true`    | Poll for changes. Required for Docker bind mounts and network shares; set `false` for a local disk.   |
+| `WATCHED_FOLDER_POLLING` | `true`    | Poll for changes. Required for Docker Desktop and network shares; can be `false` for a local disk or Docker on a Linux host. |
 
 ## Common Configuration Examples
 

--- a/docs/configuration/environment_variables.mdx
+++ b/docs/configuration/environment_variables.mdx
@@ -61,6 +61,16 @@ Technical configuration options for advanced use cases, debugging, and integrati
 | `DISABLE_SWAGGER_OPENAPI`   | `false`                        | Disable Swagger UI and OpenAPI endpoints                 |
 | `GENERATE_SWAGGER_JSON`     | `false`                        | Generate swagger.json file in media folder               |
 
+### Watched Folder
+
+FDM Monster can watch a folder and route dropped files to the right printer automatically. See [Print File Routing](../software_usage/print_file_routing.mdx) for the full guide.
+
+| Variable                 | Default   | Description                                                                                          |
+|--------------------------|-----------|------------------------------------------------------------------------------------------------------|
+| `WATCHED_FOLDER_PATH`    | -         | Absolute path to the folder FDM Monster watches. Unset disables the feature.                          |
+| `WATCHED_FOLDER_MODE`    | `consume` | `consume` moves imported files out of the folder; `library` copies them, leaving the originals.       |
+| `WATCHED_FOLDER_POLLING` | `true`    | Poll for changes. Required for Docker bind mounts and network shares; set `false` for a local disk.   |
+
 ## Common Configuration Examples
 
 ### Production Setup

--- a/docs/software_usage/print_file_routing.mdx
+++ b/docs/software_usage/print_file_routing.mdx
@@ -190,7 +190,11 @@ volumes:
   fdm-monster-watched:
 ```
 
-On the slicing PC, open the share (`\\<linux-host-ip>\fdm-monster` on Windows, or map it as a network drive), sign in as `slicer`, and send your gcode files straight into the `by-printer/` and `by-tag/` subfolders.
+:::warning
+The compose file above ships a **placeholder password** — `changeme`. Set a real one in `ACCOUNT_slicer` before you start the containers: the share is writable by anyone who can reach it on your network.
+:::
+
+On the slicing PC, open the share (`\\<linux-host-ip>\fdm-monster` on Windows, or map it as a network drive) and sign in with the `slicer` account from the compose file. Then send your gcode files straight into the `by-printer/` and `by-tag/` subfolders.
 
 What matters here:
 

--- a/docs/software_usage/print_file_routing.mdx
+++ b/docs/software_usage/print_file_routing.mdx
@@ -72,6 +72,8 @@ your-watched-folder/
 
 You do not maintain these subfolders yourself. FDM Monster keeps them in step with your setup: add a printer or create a tag, and its folder appears, ready to receive files.
 
+The folders belong to whatever user account FDM Monster runs as. Nothing stops you renaming, moving or deleting them — FDM Monster simply recreates any that are missing the next time it starts, or whenever a printer or tag changes.
+
 ### Sending a file to a printer
 
 To route a file, drop it into the subfolder that matches where you want it:
@@ -87,15 +89,27 @@ By default FDM Monster **moves** each file out of the watched folder as it impor
 
 If you would rather leave your files in place — for instance the watched folder doubles as your own gcode library — set `WATCHED_FOLDER_MODE=library`. FDM Monster then **copies** each file instead, and remembers what it has already imported, so re-scanning the folder will not import the same file twice.
 
+:::note
+When the watched folder is on a different drive or filesystem than FDM Monster's data directory, `consume` mode cannot move a file in a single step — it copies the file in, then deletes the original. The result is identical; it just happens in two stages.
+:::
+
 ### Watched folders on shares and Docker
 
-FDM Monster notices a new file in one of two ways. On a normal local disk it can let the operating system tell it the moment a file appears. Across a Docker bind mount or a network share (NFS/SMB) those notifications never arrive — so instead FDM Monster **polls** the folder, checking it about once a second.
+FDM Monster spots a new file in one of two ways. When it can watch the folder's real filesystem directly, the operating system tells it the instant a file appears. When something stands in between — the Docker Desktop VM on Windows or macOS, or a network share — those notifications never arrive, so FDM Monster falls back to **polling**, re-scanning the folder about once a second.
 
-Polling is on by default (`WATCHED_FOLDER_POLLING=true`) because it works everywhere. If your watched folder is on a normal local disk, you can set `WATCHED_FOLDER_POLLING=false` for instant, lower-overhead detection.
+`WATCHED_FOLDER_POLLING` chooses between them. It is `true` by default because polling works everywhere; turn it off where FDM Monster can see the folder's filesystem directly:
+
+| Where the watched folder lives                             | `WATCHED_FOLDER_POLLING`      |
+|-------------------------------------------------------------|-------------------------------|
+| A local folder — a bare install, or Docker on a Linux host  | `false` — native events work  |
+| Docker Desktop on Windows or macOS                          | `true`                        |
+| A network share (NFS or SMB) mounted as the watched folder  | `true`                        |
 
 :::tip
-Running FDM Monster straight on Linux (the one-click install) with the watched folder on the same disk? Set `WATCHED_FOLDER_POLLING=false` — the operating system reports new files immediately, at no cost. Keep polling on for Docker Desktop bind mounts and for any network share.
+The rule of thumb: polling is only needed when something stands between FDM Monster and the folder's real filesystem — the Docker Desktop VM, or a network mount. A bare install, or Docker on a plain Linux host, can run with `WATCHED_FOLDER_POLLING=false`.
 :::
+
+For a worked example — slicing from a desktop PC into a Dockerised install on Linux — see [Example: sharing the watched folder over Samba](#example-sharing-the-watched-folder-over-samba) at the end of this page.
 
 ## When a file matches more than one printer
 
@@ -127,3 +141,53 @@ Every file sliced from that profile now carries its target. Carrying a target is
 ### When the folder and the file disagree
 
 A file can carry both signals — it sits in a `by-printer/` folder, and its gcode names a different target. The **folder always wins**. FDM Monster logs a warning when the two disagree, so a misfiled print is easy to spot.
+
+## Example: sharing the watched folder over Samba
+
+A common farm setup runs FDM Monster in Docker on a Linux host — a server or a Raspberry Pi — while you slice on a separate (possibly Windows) PC. To get sliced files into the watched folder, add a **Samba server** alongside FDM Monster in the same `docker-compose.yml`, both sharing one volume. None of this is FDM Monster-specific — it is ordinary Docker and Samba plumbing — but here is a starting point.
+
+```yaml
+services:
+  fdm-monster:
+    container_name: fdm-monster
+    image: fdmmonster/fdm-monster:2
+    restart: unless-stopped
+    ports:
+      - "4000:4000"
+    environment:
+      - WATCHED_FOLDER_PATH=/watched
+    volumes:
+      - fdm-monster-media:/app/media
+      - fdm-monster-database:/app/database
+      - fdm-monster-watched:/watched
+
+  samba:
+    container_name: fdm-monster-samba
+    image: ghcr.io/servercontainers/samba
+    restart: unless-stopped
+    ports:
+      - "445:445"
+    environment:
+      - ACCOUNT_slicer=changeme
+      - UID_slicer=1000
+      - "SAMBA_VOLUME_CONFIG_fdmmonster=[fdm-monster]; path = /watched; valid users = slicer; read only = no; browseable = yes"
+    volumes:
+      - fdm-monster-watched:/watched
+
+volumes:
+  fdm-monster-media:
+  fdm-monster-database:
+  fdm-monster-watched:
+```
+
+On the slicing PC, open the share (`\\<linux-host-ip>\fdm-monster` on Windows, or map it as a network drive), sign in as `slicer`, and send your gcode files straight into the `by-printer/` and `by-tag/` subfolders.
+
+What matters here:
+
+- Both containers mount the `fdm-monster-watched` volume. FDM Monster watches it; the Samba container publishes it on the network as a share named **`fdm-monster`** — so it is obvious what it is from the slicing PC. The only FDM Monster-specific lines are `WATCHED_FOLDER_PATH` and that shared volume.
+- FDM Monster sees `/watched` as a plain local volume on the Linux host, so native file events work — `WATCHED_FOLDER_POLLING` can stay off. The SMB layer sits between Samba and the slicing PC; FDM Monster never crosses it.
+- There is no _official_ Samba image. This uses [servercontainers/samba](https://github.com/ServerContainers/samba), one of the actively-maintained choices ([crazymax/samba](https://github.com/crazy-max/docker-samba) is another). Avoid the `dperson/samba` that many older guides still reach for — it is effectively unmaintained. The `ACCOUNT_` and `SAMBA_VOLUME_CONFIG_` settings follow servercontainers/samba's own documentation; check it for the current syntax.
+- Files arriving over Samba must be readable by — and, in `consume` mode, deletable by — the user FDM Monster runs as. Set `UID_slicer` to that user's UID.
+- Port 445 is SMB; expose it only on a trusted LAN, and change `changeme` to a real password.
+
+The reverse direction works too: if your files already live on a NAS, FDM Monster can be the network *client* instead — back the `fdm-monster-watched` volume with a `cifs` (or `nfs`) volume driver pointing at the NAS, and drop the Samba container. In that setup FDM Monster does cross a network mount, so keep `WATCHED_FOLDER_POLLING=true`.

--- a/docs/software_usage/print_file_routing.mdx
+++ b/docs/software_usage/print_file_routing.mdx
@@ -70,7 +70,7 @@ your-watched-folder/
 - `by-printer/` holds one subfolder per printer, named exactly after that printer.
 - `by-tag/` holds one subfolder per tag — a tag being a group of printers you have defined in FDM Monster.
 
-You do not maintain these subfolders yourself. FDM Monster keeps them in step with your setup: add a printer or create a tag, and its folder appears, ready to receive files.
+You **do not** maintain these subfolders yourself. FDM Monster keeps them in sync with your setup: add a printer or create a tag, and its folder appears, ready to receive files.
 
 The folders belong to whatever user account FDM Monster runs as. Nothing stops you renaming, moving or deleting them — FDM Monster simply recreates any that are missing the next time it starts, or whenever a printer or tag changes.
 

--- a/docs/software_usage/print_file_routing.mdx
+++ b/docs/software_usage/print_file_routing.mdx
@@ -113,7 +113,7 @@ For a worked example — slicing from a desktop PC into a Dockerised install on 
 
 ## When a file matches more than one printer
 
-A tag usually covers several printers, so a file dropped into a `by-tag/` folder rarely points at a single machine. FDM Monster will not guess which one — it imports the file but does not start it anywhere. The same is true of a file whose target matched nothing at all.
+A tag usually covers several printers, so a file dropped into a `by-tag/` folder rarely points at a single machine. FDM Monster will not guess which one — it imports the file but does not start it anywhere. The same is true of a file whose target matched nothing at all, or whose `fdmm_target` matched both a printer and a tag.
 
 These files gather on the **Print Jobs** page, under **awaiting printer assignment**. Open it, choose the printer you want from the file's group, and FDM Monster queues the file on that machine. Nothing prints until you have made that choice.
 
@@ -127,7 +127,17 @@ Add a single comment line to your slicer's **start gcode**:
 ; fdmm_target = prusa-mk4
 ```
 
-Whatever you put after `fdmm_target =` is the routing target — a printer name or a tag name, the same labels the folders use. It is only a comment, so the printer ignores it entirely. Where to add it depends on your slicer:
+`fdmm_target` takes a printer name or a tag name, and FDM Monster works out which. It is only a comment, so the printer ignores it.
+
+There is one catch: if a **printer and a tag share a name**, a bare `fdmm_target` is ambiguous — FDM Monster will not guess, and the file is held for [manual routing](#when-a-file-matches-more-than-one-printer). When that can happen, name the kind in the token, the same way the `by-printer/` and `by-tag/` folders do:
+
+| Comment | Routes to |
+|---|---|
+| `; fdmm_target = voron` | A printer **or** a tag named `voron` — only safe when that name is unique |
+| `; fdmm_target_printer = voron` | The **printer** named `voron` |
+| `; fdmm_target_tag = voron` | The **tag** named `voron` |
+
+Where to add the comment depends on your slicer:
 
 | Slicer                    | Location                                                  |
 |---------------------------|-----------------------------------------------------------|

--- a/docs/software_usage/print_file_routing.mdx
+++ b/docs/software_usage/print_file_routing.mdx
@@ -70,7 +70,7 @@ your-watched-folder/
 - `by-printer/` holds one subfolder per printer, named exactly after that printer.
 - `by-tag/` holds one subfolder per tag — a tag being a group of printers you have defined in FDM Monster.
 
-You **do not** maintain these subfolders yourself. FDM Monster keeps them in sync with your setup: add a printer or create a tag, and its folder appears, ready to receive files.
+You **do not** maintain these subfolders yourself. FDM Monster keeps them in sync with your setup: add a printer or create a tag and its folder appears, ready to receive files; rename or remove one and the stale folder is cleared away — kept only if it still holds files you have not imported yet.
 
 The folders belong to whatever user account FDM Monster runs as. Nothing stops you renaming, moving or deleting them — FDM Monster simply recreates any that are missing the next time it starts, or whenever a printer or tag changes.
 

--- a/docs/software_usage/print_file_routing.mdx
+++ b/docs/software_usage/print_file_routing.mdx
@@ -1,0 +1,129 @@
+---
+title: Print File Routing
+description: Let FDM Monster send each sliced file to the right printer
+slug: /software_usage/print_file_routing
+---
+
+With a single printer, printing a file is easy: you upload it and you print. Once you run several printer models — or a whole farm — deciding which machine each sliced file belongs on, every single time, turns into a chore.
+
+Print file routing hands that job to FDM Monster. You tell it which printer (or which group of printers) a file is meant for, and it imports the file and queues it on the right machine for you.
+
+## How routing works
+
+To route a file you give it a **routing target** — a single short label that names where the file should go. A routing target is either:
+
+- the **name of a printer** — the file goes to that one printer; or
+- the **name of a tag** — a tag being a group of printers you have defined — and the file is meant for that whole group.
+
+A file gets its routing target from one of **two sources**, and you use whichever suits you:
+
+- **The folder you drop it in.** A watched folder keeps a subfolder for every printer and every tag; the subfolder a file lands in _is_ its routing target.
+- **A comment inside the gcode.** A single line your slicer bakes into the file names the target, so the file carries it wherever it goes.
+
+It is normally one or the other — not both. If a file somehow has both (it sits in a routing folder _and_ its gcode names a target), the **folder wins**.
+
+Once FDM Monster knows a file's target, what happens next depends on how many printers it resolves to:
+
+- **Exactly one printer** → the file is queued on that printer automatically.
+- **A group of printers, or nothing at all** → the file is imported but not started anywhere; you choose the printer yourself. See [When a file matches more than one printer](#when-a-file-matches-more-than-one-printer).
+
+The rest of this page covers each source in turn, starting with the watched folder — the simpler of the two.
+
+## Routing with a watched folder
+
+A watched folder is an ordinary folder on disk that FDM Monster keeps an eye on. Drop a sliced file into it and FDM Monster imports and routes the file — no slicer configuration, it works with any slicer, and it works just as well for gcode you downloaded from the internet.
+
+### Turning it on
+
+Point FDM Monster at a folder with the `WATCHED_FOLDER_PATH` environment variable. Until that is set, the feature stays off.
+
+How you set it depends on how FDM Monster is installed:
+
+- **Linux (one-click install):** add the line to `~/.fdm-monster-data/.env`, then run `fdmm restart`.
+- **Docker / Docker Compose:** pass it with `-e` or the `environment:` section, and make sure the folder is mounted into the container.
+
+The watched folder has three settings in total:
+
+| Variable                 | Default     | Description                                                                 |
+|--------------------------|-------------|-----------------------------------------------------------------------------|
+| `WATCHED_FOLDER_PATH`    | _(unset)_   | Absolute path to the folder FDM Monster watches. Unset means the feature is off. |
+| `WATCHED_FOLDER_MODE`    | `consume`   | Whether imported files are moved out of the folder or copied. See [Keeping or consuming your files](#keeping-or-consuming-your-files). |
+| `WATCHED_FOLDER_POLLING` | `true`      | How FDM Monster notices new files. See [Watched folders on shares and Docker](#watched-folders-on-shares-and-docker). |
+
+:::note
+Environment variable changes only take effect after FDM Monster restarts. The [Environment Variables guide](../configuration/environment_variables.mdx) covers where the `.env` file lives for each kind of installation.
+:::
+
+### How the folder is organised
+
+The first time FDM Monster starts with a watched folder set, it creates two folders inside it:
+
+```
+your-watched-folder/
+  by-printer/
+    Voron 2.4/
+    Prusa MK4/
+  by-tag/
+    prusa-fleet/
+```
+
+- `by-printer/` holds one subfolder per printer, named exactly after that printer.
+- `by-tag/` holds one subfolder per tag — a tag being a group of printers you have defined in FDM Monster.
+
+You do not maintain these subfolders yourself. FDM Monster keeps them in step with your setup: add a printer or create a tag, and its folder appears, ready to receive files.
+
+### Sending a file to a printer
+
+To route a file, drop it into the subfolder that matches where you want it:
+
+- `by-printer/Prusa MK4/bracket.gcode` → imported and queued on the Prusa MK4.
+- `by-tag/prusa-fleet/bracket.gcode` → meant for every printer tagged `prusa-fleet`.
+
+FDM Monster picks up `.gcode`, `.bgcode` and `.3mf` files; anything else in the folder is ignored. A file dropped loose in the root of the watched folder, or in some folder of your own, is still imported — it simply has no folder-based target, so it falls back to the [gcode comment](#routing-from-your-slicer-instead) or waits to be assigned.
+
+### Keeping or consuming your files
+
+By default FDM Monster **moves** each file out of the watched folder as it imports it (`WATCHED_FOLDER_MODE=consume`). The folder behaves like an inbox that empties itself, so you can always see at a glance what has not been processed yet.
+
+If you would rather leave your files in place — for instance the watched folder doubles as your own gcode library — set `WATCHED_FOLDER_MODE=library`. FDM Monster then **copies** each file instead, and remembers what it has already imported, so re-scanning the folder will not import the same file twice.
+
+### Watched folders on shares and Docker
+
+FDM Monster notices a new file in one of two ways. On a normal local disk it can let the operating system tell it the moment a file appears. Across a Docker bind mount or a network share (NFS/SMB) those notifications never arrive — so instead FDM Monster **polls** the folder, checking it about once a second.
+
+Polling is on by default (`WATCHED_FOLDER_POLLING=true`) because it works everywhere. If your watched folder is on a normal local disk, you can set `WATCHED_FOLDER_POLLING=false` for instant, lower-overhead detection.
+
+:::tip
+Running FDM Monster straight on Linux (the one-click install) with the watched folder on the same disk? Set `WATCHED_FOLDER_POLLING=false` — the operating system reports new files immediately, at no cost. Keep polling on for Docker Desktop bind mounts and for any network share.
+:::
+
+## When a file matches more than one printer
+
+A tag usually covers several printers, so a file dropped into a `by-tag/` folder rarely points at a single machine. FDM Monster will not guess which one — it imports the file but does not start it anywhere. The same is true of a file whose target matched nothing at all.
+
+These files gather on the **Print Jobs** page, under **awaiting printer assignment**. Open it, choose the printer you want from the file's group, and FDM Monster queues the file on that machine. Nothing prints until you have made that choice.
+
+## Routing from your slicer instead
+
+If you would rather not sort files into folders — or you want a file to carry its destination with it wherever it travels — you can write the routing target into the gcode itself.
+
+Add a single comment line to your slicer's **start gcode**:
+
+```
+; fdmm_target = prusa-mk4
+```
+
+Whatever you put after `fdmm_target =` is the routing target — a printer name or a tag name, the same labels the folders use. It is only a comment, so the printer ignores it entirely. Where to add it depends on your slicer:
+
+| Slicer                    | Location                                                  |
+|---------------------------|-----------------------------------------------------------|
+| PrusaSlicer / SuperSlicer | Printer Settings → Custom G-code → Start G-code            |
+| OrcaSlicer / Bambu Studio | Printer Settings → Machine G-code → Machine start G-code   |
+| Cura                      | Preferences → Printers → Machine Settings → Start G-code   |
+| Simplify3D                | Process → Scripts → Starting Script                        |
+
+Every file sliced from that profile now carries its target. Carrying a target is not the same as being routed, though: as with a folder, the file is queued automatically only when the target names exactly **one** printer — a tag covering several printers, or a name FDM Monster does not recognise, leaves the file in [awaiting printer assignment](#when-a-file-matches-more-than-one-printer).
+
+### When the folder and the file disagree
+
+A file can carry both signals — it sits in a `by-printer/` folder, and its gcode names a different target. The **folder always wins**. FDM Monster logs a warning when the two disagree, so a misfiled print is easy to spot.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -55,6 +55,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'software_usage/creating_printers',
         'software_usage/organizing_floors',
+        'software_usage/print_file_routing',
       ],
     },
     {


### PR DESCRIPTION
Part of fdm-monster/fdm-monster#5290.

New **Software usage → Print File Routing** page: how routing works, the watched folder (`by-printer/`/`by-tag/`, consume vs library, polling), the `fdmm_target` slicer tokens, what happens when a file matches more than one printer, and a deployment-examples section (incl. a Samba-share docker-compose for slicing from a separate PC).

Also adds the `WATCHED_FOLDER_*` variables to the Environment Variables reference, plus a sidebar entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation: Print File Routing Guide

Added a new user-facing guide explaining how FDM Monster automatically routes sliced files to the correct printer or printer group. Highlights:

- New "Print File Routing" page describing watched-folder routing and slicer-embedded routing tokens (fdmm_target, plus fdmm_target_printer / fdmm_target_tag).
- Clear behavior for conflicts and multi-printer/tag cases (files that resolve to more than one printer are imported and await manual assignment).
- New environment variables documented for watched folders: WATCHED_FOLDER_PATH, WATCHED_FOLDER_MODE (consume vs library), and WATCHED_FOLDER_POLLING — with polling guidance scoped to Docker Desktop and network shares.
- Practical deployment example: Docker + Samba compose snippet for sharing a watched folder from another PC.
- Sidebar updated to include the new page.

This should make it easier for users to set up distributed or multi‑printer workflows and networked slicing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fdm-monster/fdm-monster-docs/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->